### PR TITLE
Generalize pyvenv-mode to non-python buffers

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -204,11 +204,11 @@ Will show the current virtual env in the mode line, and respect a
   (cond
    (pyvenv-mode
     (add-to-list 'mode-line-misc-info pyvenv-mode-line-indicator)
-    (add-hook 'python-mode-hook 'pyvenv-set-file-virtualenv))
+    (add-hook 'hack-local-variables-hook #'pyvenv-set-file-virtualenv))
    ((not pyvenv-mode)
     (setq mode-line-misc-info (delete pyvenv-mode-line-indicator
                                       mode-line-misc-info))
-    (remove-hook 'python-mode-hook 'pyvenv-set-file-virtualenv))))
+    (remove-hook 'hack-local-variables-hook #'pyvenv-set-file-virtualenv))))
 
 (defun pyvenv-set-file-virtualenv ()
   "If `pyvenv-workon' is set, switch to that virtual env."


### PR DESCRIPTION
Inspect the file virtualenv from `pyvenv-workon` regardless of the current major mode, by hooking into `hack-local-variables-hook` instead of `python-mode`.  This makes this package useful for other major modes which may want to use the current virtualenv as well, for instance ReST mode buffers for the Sphinx documentation of a Python project.

If the user stills wants to enable the virtualenv only in Python Mode buffers, they can just limit the dir local variables to python mode.

Also, with this change pyvenv-mode does not longer attempt to inspect `pyvenv-mode` _before_ local variables were loaded, because `hack-local-variables-hook` is guaranteed to be called after local variables.  For major mode hooks, there is no such guarantee, and in fact, at least on recent Emacs versions major mode hooks are called before local variables!
