### PR TITLE
use full basename (permit periods) in pyvenv-virtual-env-name

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -135,7 +135,7 @@ This is usually the base name of `pyvenv-virtual-env'.")
   (setq directory (expand-file-name directory))
   (pyvenv-deactivate)
   (setq pyvenv-virtual-env directory
-        pyvenv-virtual-env-name (file-name-base directory))
+        pyvenv-virtual-env-name (file-name-nondirectory directory))
   ;; Preserve variables from being overwritten.
   (let ((old-exec-path exec-path)
         (old-process-environment process-environment))


### PR DESCRIPTION
Jorgen-

Thanks for pyvenv. 

I name virtualenvs like default-2.7, default-3.3, default-3.4, etc. The use of file-name-base in pyvenv.el caused pyvenv-virtual-env-name to be truncated at the first period. This patch uses file-name-nondirectory to preserve the period (i.e., more like basename in GNU coreutils).

Cheers,
Reece
