### PR TITLE
READY FOR REVIEW - Fix pyvenv-run-virtualenvwrapper-hook

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -362,12 +362,11 @@ CAREFUL! This will modify your `process-environment' and
     (with-temp-buffer
       (let ((tmpfile (make-temp-file "pyvenv-virtualenvwrapper-")))
         (unwind-protect
-            (progn
+            (let ((default-directory (pyvenv-workon-home)))
               (apply #'call-process
                      pyvenv-virtualenvwrapper-python
                      nil t nil
-                     "-c"
-                     "from virtualenvwrapper.hook_loader import main; main()"
+                     "-m" "virtualenvwrapper.hook_loader"
                      "--script" tmpfile
                      (if (getenv "HOOK_VERBOSE_OPTION")
                          (cons (getenv "HOOK_VERBOSE_OPTION")


### PR DESCRIPTION
Fixes #59. Brings `pyvenv-run-virtualenvwrapper-hook` closer to shell
implementation by changing `default-directory` to `pyvenv-workon-home`
before calling `pyvenv-virtualenvwrapper-python ... "-m"
"virtualenvwrapper.hook_loader" ...`.