### PR TITLE
Add check for bin/python to verify directory is a virtual env

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -268,6 +268,8 @@ configured."
       (dolist (name (directory-files workon-home))
         (when (or (file-exists-p (format "%s/%s/bin/activate"
                                          workon-home name))
+		  (file-exists-p (format "%s/%s/bin/python"
+					 workon-home name))
                   (file-exists-p (format "%s/%s/Scripts/activate.bat"
                                          workon-home name)))
           (setq result (cons name result))))


### PR DESCRIPTION
conda create stopped creating bin/activate which causes envs not to be
listed.  Addresses #67