### PR TITLE
Set the shell while running hooks with a customization variable

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -97,6 +97,16 @@ educated guess, but that can be off."
   :safe #'file-directory-p
   :group 'pyvenv)
 
+(defcustom pyvenv-exec-shell
+  (or (executable-find "sh")
+      (executable-find "bash"))
+  "The path to a POSIX compliant shell to use for running
+  virtualenv hooks. Useful if you use a non-POSIX shell (e.g.
+  fish)."
+  :type '(file :must-match t)
+  :safe #'file-directory-p
+  :group 'pyvenv)
+
 ;; API for other libraries
 
 (defvar pyvenv-virtual-env nil
@@ -383,7 +393,8 @@ CAREFUL! This will modify your `process-environment' and
 `exec-path'."
   (when (pyvenv-virtualenvwrapper-supported)
     (with-temp-buffer
-      (let ((tmpfile (make-temp-file "pyvenv-virtualenvwrapper-")))
+      (let ((tmpfile (make-temp-file "pyvenv-virtualenvwrapper-"))
+            (shell-file-name pyvenv-exec-shell))
         (unwind-protect
             (let ((default-directory (pyvenv-workon-home)))
               (apply #'call-process

--- a/pyvenv.el
+++ b/pyvenv.el
@@ -104,7 +104,6 @@ educated guess, but that can be off."
   virtualenv hooks. Useful if you use a non-POSIX shell (e.g.
   fish)."
   :type '(file :must-match t)
-  :safe #'file-directory-p
   :group 'pyvenv)
 
 ;; API for other libraries
@@ -278,8 +277,8 @@ configured."
       (dolist (name (directory-files workon-home))
         (when (or (file-exists-p (format "%s/%s/bin/activate"
                                          workon-home name))
-		  (file-exists-p (format "%s/%s/bin/python"
-					 workon-home name))
+                  (file-exists-p (format "%s/%s/bin/python"
+                                         workon-home name))
                   (file-exists-p (format "%s/%s/Scripts/activate.bat"
                                          workon-home name)))
           (setq result (cons name result))))


### PR DESCRIPTION
This commit defines a new customization var, `pyvenv-exec-shell`, the value of
which should be a POSIX-compliant shell binary. We then set this to be the value
of `shell-file-name` during hook loading. This allows those of us using
suchlikeas fish shell to have an error free activate/deactivate experience.

Closes #49