### PR TITLE
Support anaconda environments under windows

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -310,6 +310,8 @@ configured."
                   (file-exists-p (format "%s/%s/bin/python"
                                          workon-home name))
                   (file-exists-p (format "%s/%s/Scripts/activate.bat"
+                                         workon-home name))
+                  (file-exists-p (format "%s/%s/python.exe"
                                          workon-home name)))
           (setq result (cons name result))))
       (sort result (lambda (a b)


### PR DESCRIPTION
Fixes #56 
Searches for python.exe in Windows Anaconda virtual environments that do not have Scripts/activate.bat.