### PR TITLE
Set venv name as parent directory if it's in a directory ".venv"

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -195,6 +195,13 @@ This is usually the base name of `pyvenv-virtual-env'.")
                                  (directory-file-name directory))
         python-shell-virtualenv-path directory
         python-shell-virtualenv-root directory)
+  ;; Set venv name as parent directory for generic directories
+  (when (member pyvenv-virtual-env-name '("venv" ".venv"))
+    (setq pyvenv-virtual-env-name
+          (file-name-nondirectory
+           (directory-file-name
+            (file-name-directory
+             (directory-file-name directory))))))
   ;; Preserve variables from being overwritten.
   (let ((old-exec-path exec-path)
         (old-eshell-path eshell-path-env)


### PR DESCRIPTION
Fixes #77 