### PR TITLE
Fix path windows

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -214,11 +214,11 @@ This is usually the base name of `pyvenv-virtual-env'.")
   (run-hooks 'pyvenv-pre-activate-hooks)
   (let ((new-directories (append
                           ;; Unix
-                          (when (file-exists-p (format "%s/bin" directory))
-                            (list (format "%s/bin" directory)))
+                          (when (file-exists-p (expand-file-name "bin" directory))
+                            (list (expand-file-name "bin" directory)))
                           ;; Windows
-                          (when (file-exists-p (format "%s/Scripts" directory))
-                            (list (format "%s/Scripts" directory)
+                          (when (file-exists-p (expand-file-name "Scripts" directory))
+                            (list (expand-file-name "Scripts" directory)
                                   ;; Apparently, some virtualenv
                                   ;; versions on windows put the
                                   ;; python.exe in the virtualenv root

--- a/pyvenv.el
+++ b/pyvenv.el
@@ -231,7 +231,7 @@ This is usually the base name of `pyvenv-virtual-env'.")
           ;; but not to `process-environment'?
           exec-path (append new-directories exec-path)
           ;; set eshell path to same as exec-path
-          eshell-path-env (mapconcat 'identity exec-path ":")
+          eshell-path-env (mapconcat 'identity exec-path path-separator)
           process-environment (append
                                (list
                                 (format "VIRTUAL_ENV=%s" directory)


### PR DESCRIPTION
On windows, when doing `pyvenv-activate`, and then, in an eshell type `which python`, I receive the message
    Host ‘c’ looks like a remote host, ‘Scripts’ can only use the local host
The `PATH` and `eshell-path-env` seem to be broken. I'm not able to execute any command after `pyvenv-activate`, until I do `pyvenv-deactivate` again.

Using `path-separator`, which is different on windows, and removing a duplicate directory-separator fixes the issue for me. Please check and accept this patch.