### PR TITLE
Fallback to 'venv' when 'virtualenv' is not installed

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -176,10 +176,20 @@ This is usually the base name of `pyvenv-virtual-env'.")
                           venv-name)))
     (unless (file-exists-p venv-dir)
       (run-hooks 'pyvenv-pre-create-hooks)
-      (with-current-buffer (generate-new-buffer "*virtualenv*")
-        (call-process "virtualenv" nil t t
-                      "-p" python-executable venv-dir)
-        (display-buffer (current-buffer)))
+      (cond
+       ((executable-find "virtualenv")
+        (with-current-buffer (generate-new-buffer "*virtualenv*")
+          (call-process "virtualenv" nil t t
+                        "-p" python-executable venv-dir)
+          (display-buffer (current-buffer))))
+       ((= 0 (call-process python-executable nil nil nil
+                           "-m" "venv" "-h"))
+        (with-current-buffer (generate-new-buffer "*venv*")
+          (call-process python-executable nil t t
+                        "-m" "venv" venv-dir)
+          (display-buffer (current-buffer))))
+       (t
+        (error "Pyvenv necessitates the 'virtualenv' python package")))
       (run-hooks 'pyvenv-post-create-hooks))
     (pyvenv-activate venv-dir)))
 


### PR DESCRIPTION
Hi Jorgen, 
Hope you are doing well.

I got a little problem with Pyvenv following an update in Elpy (see issue [1652](https://github.com/jorgenschaefer/elpy/issues/1652)).

In summary, Elpy now uses `pyvenv-create` to generate a dedicated virtualenv for the RPC.
As `pyvenv-create` relies on `virtualenv`, it can be a problem if it is not installed.

This PR checks for the presence of `virtualenv` and falls back to the builtins `venv` module if necessary (if both are unavailable, it warns the user).