### PR TITLE
Ignore pyvenv-deactivate error in pyvenv-activate

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -199,7 +199,7 @@ This is usually the base name of `pyvenv-virtual-env'.")
   "Activate the virtual environment in DIRECTORY."
   (interactive "DActivate venv: ")
   (setq directory (expand-file-name directory))
-  (pyvenv-deactivate)
+  (ignore-errors (pyvenv-deactivate))
   (setq pyvenv-virtual-env (file-name-as-directory directory)
         pyvenv-virtual-env-name (file-name-nondirectory
                                  (directory-file-name directory))


### PR DESCRIPTION
The function pyvenv-deactivate maybe emit an error, it should be ignored while the deactivate() is called from function pyvenv-activate.