### PR TITLE
Add new `pyvenv-default-virtual-env-name' customizable variable

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -107,6 +107,12 @@ educated guess, but that can be off."
   :type '(file :must-match t)
   :group 'pyvenv)
 
+(defcustom pyvenv-default-virtual-env-name nil
+  "Default directory to use when prompting for a virtualenv directory
+in `pyvenv-activate'."
+  :type 'string
+  :group 'pyvenv)
+
 ;; API for other libraries
 
 (defvar pyvenv-virtual-env nil
@@ -197,7 +203,8 @@ This is usually the base name of `pyvenv-virtual-env'.")
 ;;;###autoload
 (defun pyvenv-activate (directory)
   "Activate the virtual environment in DIRECTORY."
-  (interactive "DActivate venv: ")
+  (interactive (list (read-directory-name "Activate venv: " nil nil nil
+					  pyvenv-default-virtual-env-name)))
   (setq directory (expand-file-name directory))
   (pyvenv-deactivate)
   (setq pyvenv-virtual-env (file-name-as-directory directory)
@@ -205,8 +212,12 @@ This is usually the base name of `pyvenv-virtual-env'.")
                                  (directory-file-name directory))
         python-shell-virtualenv-path directory
         python-shell-virtualenv-root directory)
-  ;; Set venv name as parent directory for generic directories
-  (when (member pyvenv-virtual-env-name '("venv" ".venv"))
+  ;; Set venv name as parent directory for generic directories or for
+  ;; the user's default venv name
+  (when (or (member pyvenv-virtual-env-name '("venv" ".venv" "env" ".env"))
+	    (and pyvenv-default-virtual-env-name
+		 (string= pyvenv-default-virtual-env-name
+			  pyvenv-virtual-env-name)))
     (setq pyvenv-virtual-env-name
           (file-name-nondirectory
            (directory-file-name


### PR DESCRIPTION
This PR adds a new customizable variable, `pyvenv-default-virtual-env-name`, which is appended to the current directory when the users calls `pyvenv-activate`. By default it is set to `nil`, so nothing is appended.

Additionally, I added `env` and `.env` as standard virtual env names when deciding how to name the virtual environment on the modeline.