### PR TITLE
fix python executable used in pyvenv-run-virtualenvwrapper-hook

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -426,9 +426,12 @@ CAREFUL! If PROPAGATE-ENV is non-nil, this will modify your
               (call-process-shell-command
                (mapconcat 'identity
                           (list
-                           "python -c 'import os, json; print(json.dumps(dict(os.environ)))'"
+                           (format "%s -c 'import os, json; print(json.dumps(dict(os.environ)))'"
+                                   pyvenv-virtualenvwrapper-python)
                            (format ". '%s'" tmpfile)
-                           "python -c 'import os, json; print(\"\\n=-=-=\"); print(json.dumps(dict(os.environ)))'")
+                           (format
+                            "%s -c 'import os, json; print(\"\\n=-=-=\"); print(json.dumps(dict(os.environ)))'"
+                            pyvenv-virtualenvwrapper-python))
                           "; ")
                nil t nil))
           (delete-file tmpfile)))


### PR DESCRIPTION
Hardcoded `python` was used to execute virtualenvwrapper module when
running hooks.

This can fail in pre_activate since the new virtualenv is not yet
activated: there's no guarantee that `python` exists in the system.

Using the configurable variable `pyvenv-virtualenvwrapper-python` is
more correct.

Note that this was happening before commit 74ab422 but that commit
made the problem evident to me since the process output parsing has
changed.