### PR TITLE
fixes https://github.com/jorgenschaefer/elpy/issues/1937

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -543,7 +543,10 @@ Right now, this just checks if WORKON_HOME is set."
   (getenv "WORKON_HOME"))
 
 (defun pyvenv--virtual-env-bin-dirs (virtual-env)
-  (let ((virtual-env (directory-file-name virtual-env)))
+  (let ((virtual-env
+	 (if (string= "/" (directory-file-name virtual-env))
+	     ""
+	   (directory-file-name virtual-env))))
    (append
     ;; Unix
     (when (file-exists-p (format "%s/bin" virtual-env))


### PR DESCRIPTION
When virtual-env is "/", the associated bin dir should be "/bin" rather than "//bin". 