### PR TITLE
Use expand-file-name for environment variable WORKON_HOME in pyvenv-workon-home

### DIFF
--- a/pyvenv.el
+++ b/pyvenv.el
@@ -533,8 +533,9 @@ back to the default of $WORKON_HOME or even just ~/.virtualenvs/."
   "Return the current workon home.
 
 This is the value of $WORKON_HOME or ~/.virtualenvs."
-  (or (getenv "WORKON_HOME")
-      (expand-file-name "~/.virtualenvs")))
+  (expand-file-name
+   (or (getenv "WORKON_HOME")
+       "~/.virtualenvs")))
 
 (defun pyvenv-virtualenvwrapper-supported ()
   "Return true iff virtualenvwrapper is supported.


### PR DESCRIPTION
I think it's reasonable to expect to be able to set `WORKON_HOME` to something like `~/.virtualenvs` or whatever, but since my env var was set, `pyvenv-create` originally would create a directory called `$(pwd)/~/.virtualenvs`, which seems wrong.